### PR TITLE
Add structurify config and disable end_house

### DIFF
--- a/config/structurify.json
+++ b/config/structurify.json
@@ -1,0 +1,22 @@
+{
+  "config_version": "2.0.22",
+  "config_datetime": "2026-05-03_01-23-17",
+  "general": {
+    "disable_all_structures": false,
+    "prevent_structure_overlap": false,
+    "enable_global_spacing_and_separation_modifier": false,
+    "global_spacing_and_separation_modifier": 1.0
+  },
+  "structure_namespaces": [],
+  "structures": [
+    {
+      "name": "endersdelight:end_house",
+      "is_disabled": true,
+      "whitelisted_biomes": [],
+      "blacklisted_biomes": [],
+      "step": "surface_structures",
+      "terrain_adaptation": "beard_thin"
+    }
+  ],
+  "structure_sets": []
+}


### PR DESCRIPTION
Add new config/structurify.json (v2.0.22). Temp (lol) removal of endersdelight:end_house, due to bug related to end oven inventory in worldgen causing ticking crash after malformed loot index.