### PR TITLE
Add Compact Machines mod

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -2788,6 +2788,11 @@ hash = "28ce51413cf71482c76526c8413732077bf9bcd0d1ebcf3264781632b3b1e971"
 metafile = true
 
 [[files]]
+file = "mods/compact-machines.pw.toml"
+hash = "d811d8a03eb5599c316bed7c06632f7431f268aa4bc68cae81dba7fd9e951a88"
+metafile = true
+
+[[files]]
 file = "mods/configured.pw.toml"
 hash = "c1bdeff356cd2ac164e2c0e6d0ceeda234db9774c2df44fb9f0e71d3960cc3f1"
 metafile = true

--- a/mods/compact-machines.pw.toml
+++ b/mods/compact-machines.pw.toml
@@ -1,0 +1,13 @@
+name = "Compact Machines"
+filename = "compactmachines-forge-6.0.3.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "41debe12bc7b013c39998788ed02ee971a11518f"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 6000230
+project-id = 224218

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "523bc9424498aa1bfcf75a95150ae9666523394bd766da905aadda39e2b55cf5"
+hash = "252649a4d7c34416c7223f7d75308cd5ce8a8ff91ca1483fc3319e961e97da5b"
 
 [versions]
 forge = "47.4.20"


### PR DESCRIPTION
compactmachines-forge-6.0.3.jar to replace hyperbox Note: mods that create dynamically added dimensions conflict with VS's physics engine layers